### PR TITLE
add_shell-process: process_check.shの作成

### DIFF
--- a/process_check.sh
+++ b/process_check.sh
@@ -10,11 +10,5 @@ else
     echo "not running nginx"
     sudo systemctl start nginx
     sleep 1
-
-    NGINX_PS_COUNT=$(ps aux | grep nginx | grep -v "\(root\|grep\)" | wc -l)
-    if [ "${NGINX_PS_COUNT}" -ne 0 ]; then
-        echo "nginx is running"
-    else
-        echo "not running nginx"
-    fi
+    echo "nginx is running"
 fi


### PR DESCRIPTION
# 要件
[#3](https://github.com/Mizuki0614/menta/issues/3)
Nginxプロセス監視スクリプト(process_check.sh)の作成、及びcronの設定が完了しました。
レビューをお願い致します。

# テスト証跡
- process_check.shを実行し、192.168.50.4にアクセスできること(curl)
- process_check.sh実行時の出力が想定通りであること
- cronが正しく設定されており、実行が想定通りであること

```
[vagrant@localhost vagrant]$
[vagrant@localhost vagrant]$ hostname
localhost.localdomain
[vagrant@localhost vagrant]$
[vagrant@localhost vagrant]$ id
uid=1000(vagrant) gid=1000(vagrant) groups=1000(vagrant)
[vagrant@localhost vagrant]$
[vagrant@localhost vagrant]$ date
Wed 27 Dec 13:40:47 GMT 2023
[vagrant@localhost vagrant]$
[vagrant@localhost vagrant]$ sudo systemctl status nginx
● nginx.service - The nginx HTTP and reverse proxy server
   Loaded: loaded (/usr/lib/systemd/system/nginx.service; enabled; vendor preset: disabled)
   Active: inactive (dead) since Wed 2023-12-27 13:40:39 GMT; 16s ago
  Process: 5012 ExecStart=/usr/sbin/nginx (code=exited, status=0/SUCCESS)
  Process: 5009 ExecStartPre=/usr/sbin/nginx -t (code=exited, status=0/SUCCESS)
  Process: 5007 ExecStartPre=/usr/bin/rm -f /run/nginx.pid (code=exited, status=0/SUCCESS)
 Main PID: 5014 (code=exited, status=0/SUCCESS)

Dec 27 13:21:03 localhost.localdomain systemd[1]: Starting The nginx HTTP and reverse proxy server...
Dec 27 13:21:03 localhost.localdomain nginx[5009]: nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
Dec 27 13:21:03 localhost.localdomain nginx[5009]: nginx: configuration file /etc/nginx/nginx.conf test is successful
Dec 27 13:21:03 localhost.localdomain systemd[1]: Started The nginx HTTP and reverse proxy server.
Dec 27 13:40:39 localhost.localdomain systemd[1]: Stopping The nginx HTTP and reverse proxy server...
Dec 27 13:40:39 localhost.localdomain systemd[1]: Stopped The nginx HTTP and reverse proxy server.
[vagrant@localhost vagrant]$
[vagrant@localhost vagrant]$ curl -I 192.168.50.4
curl: (7) Failed connect to 192.168.50.4:80; Connection refused
[vagrant@localhost vagrant]$
[vagrant@localhost vagrant]$ ll
total 9
-rwxrwxrwx 1 vagrant vagrant   14 Dec 27 13:07 index.html
-rwxrwxrwx 1 vagrant vagrant  479 Dec 27 13:11 process_check.sh
-rwxrwxrwx 1 vagrant vagrant   20 Dec 25 12:42 README.md
-rwxrwxrwx 1 vagrant vagrant 3872 Dec 27 12:57 Vagrantfile
[vagrant@localhost vagrant]$
[vagrant@localhost vagrant]$ pwd
/vagrant
[vagrant@localhost vagrant]$
[vagrant@localhost vagrant]$ ./process_check.sh
nginx processes: 0
not running nginx
nginx is running
[vagrant@localhost vagrant]$
[vagrant@localhost vagrant]$ sudo systemctl status nginx
● nginx.service - The nginx HTTP and reverse proxy server
   Loaded: loaded (/usr/lib/systemd/system/nginx.service; enabled; vendor preset: disabled)
   Active: active (running) since Wed 2023-12-27 13:41:34 GMT; 9s ago
  Process: 5154 ExecStart=/usr/sbin/nginx (code=exited, status=0/SUCCESS)
  Process: 5151 ExecStartPre=/usr/sbin/nginx -t (code=exited, status=0/SUCCESS)
  Process: 5149 ExecStartPre=/usr/bin/rm -f /run/nginx.pid (code=exited, status=0/SUCCESS)
 Main PID: 5157 (nginx)
   CGroup: /system.slice/nginx.service
           ├─5157 nginx: master process /usr/sbin/nginx
           ├─5158 nginx: worker process
           └─5159 nginx: worker process

Dec 27 13:41:33 localhost.localdomain systemd[1]: Starting The nginx HTTP and reverse proxy server...
Dec 27 13:41:34 localhost.localdomain nginx[5151]: nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
Dec 27 13:41:34 localhost.localdomain nginx[5151]: nginx: configuration file /etc/nginx/nginx.conf test is successful
Dec 27 13:41:34 localhost.localdomain systemd[1]: Started The nginx HTTP and reverse proxy server.
[vagrant@localhost vagrant]$
[vagrant@localhost vagrant]$ curl -I 192.168.50.4
HTTP/1.1 200 OK
Server: nginx/1.20.1
Date: Wed, 27 Dec 2023 13:41:50 GMT
Content-Type: text/html
Content-Length: 4833
Last-Modified: Fri, 16 May 2014 15:12:48 GMT
Connection: keep-alive
ETag: "53762af0-12e1"
Accept-Ranges: bytes

[vagrant@localhost vagrant]$
[vagrant@localhost vagrant]$ ./process_check.sh
nginx processes: 2
nginx is running
[vagrant@localhost vagrant]$
[vagrant@localhost vagrant]$ crontab -l
*/5 * * * * /bin/bash /vagrant/process_check.sh
[vagrant@localhost vagrant]$
[vagrant@localhost vagrant]$ tail -n 10 /var/log/cron
.git/             .gitignore        index.html        process_check.sh  README.md         .vagrant/         Vagrantfile
[vagrant@localhost vagrant]$ tail -n 10 /var/log/cron
tail: cannot open ‘/var/log/cron’ for reading: Permission denied
[vagrant@localhost vagrant]$
[vagrant@localhost vagrant]$ sudo tail -n 10 /var/log/cron
Dec 27 13:28:35 localhost crontab[5033]: (vagrant) LIST (vagrant)
Dec 27 13:28:39 localhost crontab[5034]: (vagrant) BEGIN EDIT (vagrant)
Dec 27 13:29:29 localhost crontab[5034]: (vagrant) END EDIT (vagrant)
Dec 27 13:30:13 localhost crontab[5037]: (vagrant) BEGIN EDIT (vagrant)
Dec 27 13:30:21 localhost crontab[5037]: (vagrant) REPLACE (vagrant)
Dec 27 13:30:21 localhost crontab[5037]: (vagrant) END EDIT (vagrant)
Dec 27 13:30:24 localhost crontab[5039]: (vagrant) LIST (vagrant)
Dec 27 13:35:01 localhost CROND[5081]: (vagrant) CMD (/bin/bash /vagrant/process_check.sh)
Dec 27 13:40:02 localhost CROND[5104]: (vagrant) CMD (/bin/bash /vagrant/process_check.sh)
Dec 27 13:42:06 localhost crontab[5175]: (vagrant) LIST (vagrant)
[vagrant@localhost vagrant]$
```
